### PR TITLE
Add -dg -dp -dl back in and stamped calls (#702)

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -16,8 +16,9 @@ class Pogom(Flask):
         self.json_encoder = CustomJSONEncoder
         self.route("/", methods=['GET'])(self.fullmap)
         self.route("/pokemons/<stamp>", methods=['GET'])(self.pokemons)
-        self.route("/gyms/<stamp>", methods=['GET'])(self.gyms)
-        self.route("/pokestops/<stamp>", methods=['GET'])(self.pokestops)
+        self.route("/pokemons", methods=['GET'])(self.pokemons_all)
+        self.route("/gyms", methods=['GET'])(self.gyms)
+        self.route("/pokestops", methods=['GET'])(self.pokestops)
         self.route("/raw_data", methods=['GET'])(self.raw_data)
 
     def fullmap(self):
@@ -28,22 +29,25 @@ class Pogom(Flask):
 
     def get_raw_data(self, stamp):
         return {
-            'gyms': [g for g in Gym.select().dicts()],
-            'pokestops': [p for p in Pokestop.select().dicts()],
+            'gyms': [g for g in Gym.get()],
+            'pokestops': [p for p in Pokestop.get()],
             'pokemons': Pokemon.get_active(stamp)
         }
 
-    def raw_data(self, stamp):
-        return jsonify(self.get_raw_data(stamp))
+    def raw_data(self):
+        return jsonify(self.get_raw_data(None))
 
     def pokemons(self, stamp):
         return jsonify(self.get_raw_data(stamp)['pokemons'])
 
-    def pokestops(self, stamp):
-        return jsonify(self.get_raw_data(stamp)['pokestops'])
+    def pokemons_all(self):
+        return jsonify(self.get_raw_data(None)['pokemons'])
 
-    def gyms(self, stamp):
-        return jsonify(self.get_raw_data(stamp)['gyms'])
+    def pokestops(self):
+        return jsonify(self.get_raw_data(None)['pokestops'])
+
+    def gyms(self):
+        return jsonify(self.get_raw_data(None)['gyms'])
 
 
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -34,13 +34,20 @@ class Pokemon(BaseModel):
     detect_time = DateTimeField()
 
     @classmethod
-    def get_active(cls, stamp): 
-        r_stamp = datetime.fromtimestamp(int(stamp)/1e3)      
-        query = (Pokemon
-                 .select()
-                 .where(Pokemon.disappear_time > datetime.utcnow())
-                 .dicts())
-        log.info("Get Pokemons for stamp: {}".format(r_stamp))
+    def get_active(cls, stamp):
+        if stamp != None:
+            r_stamp = datetime.fromtimestamp(int(stamp)/1e3)
+            query = (Pokemon
+                     .select()
+                     .where(Pokemon.disappear_time > datetime.utcnow(), Pokemon.detect_time >= r_stamp)
+                     .dicts())
+            log.info("Get Pokemons for stamp: {}".format(r_stamp))
+        else:
+            query = (Pokemon
+                     .select()
+                     .where(Pokemon.disappear_time > datetime.utcnow())
+                     .dicts())
+            log.info("Geting all Pokemons")
         pokemons = []
         for p in query:
             p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
@@ -58,6 +65,9 @@ class Pokemon(BaseModel):
 
 
 class Pokestop(BaseModel):
+    IGNORE = True
+    LURED_ONLY = False
+
     pokestop_id = CharField(primary_key=True)
     enabled = BooleanField()
     latitude = FloatField()
@@ -65,8 +75,25 @@ class Pokestop(BaseModel):
     last_modified = DateTimeField()
     lure_expiration = DateTimeField(null=True)
 
+    @classmethod
+    def get(cls):
+        if cls.IGNORE:
+            return []
+        else:
+            if cls.LURED_ONLY:
+                return (Pokestop
+                        .select()
+                        .where(~(Pokestop.lure_expiration >> None))
+                        .dicts())
+            else:
+                return (Pokestop
+                        .select()
+                        .dicts())
+
 
 class Gym(BaseModel):
+    IGNORE = True
+
     UNCONTESTED = 0
     TEAM_MYSTIC = 1
     TEAM_VALOR = 2
@@ -81,6 +108,14 @@ class Gym(BaseModel):
     longitude = FloatField()
     last_modified = DateTimeField()
 
+    @classmethod
+    def get(cls):
+        if cls.IGNORE:
+            return [];
+        else:
+            return (Gym
+                    .select()
+                    .dicts())
 
 def parse_map(map_dict):
     pokemons = {}

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -33,7 +33,7 @@ def get_args():
     parser.add_argument('-ar', '--auto-refresh', help='Enables an autorefresh that behaves the same as'
                         ' a page reload. Needs an integer value for the amount of seconds')
     parser.add_argument('-dp', '--display-pokestops', help='Display pokéstops', action='store_true', default=False)
-    parser.add_argument('-dl', '--display-lured', help='Display only lured pokéstop', action='store_true', default=False)
+    parser.add_argument('-dl', '--display-lured', help='Display only lured pokéstop (implies --display-pokestops)', action='store_true', default=False)
     parser.add_argument('-dg', '--display-gyms', help='Display gyms', action='store_true', default=False)
     parser.add_argument('-H', '--host', help='Set web server listening host', default='127.0.0.1')
     parser.add_argument('-P', '--port', type=int, help='Set web server listening port', default=5000)

--- a/runserver.py
+++ b/runserver.py
@@ -10,7 +10,7 @@ from pogom import config
 from pogom.app import Pogom
 from pogom.utils import get_args, insert_mock_data, load_credentials
 from pogom.search import search_loop
-from pogom.models import create_tables, Pokemon
+from pogom.models import create_tables, Pokemon, Pokestop, Gym
 from pogom.pgoapi.utilities import get_pos_by_name
 
 log = logging.getLogger(__name__)
@@ -56,6 +56,15 @@ if __name__ == '__main__':
         start_locator_thread(args)
     else:
         insert_mock_data(args.location, 6)
+
+    if args.display_pokestops or args.display_lured:
+        Pokestop.IGNORE = False
+
+    if args.display_lured:
+        Pokestop.LURED_ONLY = True
+
+    if args.display_gyms:
+        Gym.IGNORE = False
 
     app = Pogom(__name__)
     config['ROOT_PATH'] = app.root_path

--- a/static/map.js
+++ b/static/map.js
@@ -91,8 +91,8 @@ initMap = function() {
         animation: google.maps.Animation.DROP
     });  
     GetNewPokemons(lastStamp);
-    GetNewGyms(lastStamp);
-    GetNewPokeStops(lastStamp);
+    GetNewGyms();
+    GetNewPokeStops();
 };
 
 GetNewPokemons = function(stamp) {
@@ -136,8 +136,8 @@ GetNewPokemons = function(stamp) {
     }).always(function() {
         setTimeout(function() {
             GetNewPokemons(lastStamp);
-            GetNewGyms(lastStamp);
-            GetNewPokeStops(lastStamp);
+            GetNewGyms();
+            GetNewPokeStops();
         }, requestInterval)
     });
 
@@ -150,8 +150,8 @@ GetNewPokemons = function(stamp) {
     });
 };
 
-GetNewGyms = function(stamp) {
-    $.getJSON("/gyms/"+stamp, function(result){
+GetNewGyms = function() {
+    $.getJSON("/gyms", function(result){
         $.each(result, function(i, item){
             var marker = new google.maps.Marker({
                 position: {lat: item.latitude, lng: item.longitude},
@@ -186,8 +186,8 @@ GetNewGyms = function(stamp) {
     });
 };
 
-GetNewPokeStops = function(stamp) {
-    $.getJSON("/pokestops/"+stamp, function(result){
+GetNewPokeStops = function() {
+    $.getJSON("/pokestops", function(result){
         $.each(result, function(i, item){
             var imagename = item.lure_expiration ? "PstopLured" : "Pstop";
             var marker = new google.maps.Marker({


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

-
-
-

If this is related to an existing ticket, include a link to it as well.

* Fix -dp, -dg, -dl

* dg: display gyms
* dp: display pokestops
* dl: display only lured pokestops (implies dp)

* Fix requests that don't require a time stamp